### PR TITLE
add missing "exec" to services, so they can be stopped&restarted properly

### DIFF
--- a/services/gitlab
+++ b/services/gitlab
@@ -34,4 +34,4 @@
 GITLAB_PATH=$HOME/gitlab
 
 cd $GITLAB_PATH
-bundle exec unicorn_rails -c "$GITLAB_PATH/config/unicorn.rb" -E "production"
+exec bundle exec unicorn_rails -c "$GITLAB_PATH/config/unicorn.rb" -E "production"

--- a/services/sidekiq
+++ b/services/sidekiq
@@ -33,4 +33,4 @@ sidekiq_logfile="$app_root/log/sidekiq.log"
 
 cd $app_root
 # Now let's go!
-bundle exec sidekiq -q post_receive -q mailer -q system_hook -q project_web_hook -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1
+exec bundle exec sidekiq -q post_receive -q mailer -q system_hook -q project_web_hook -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1


### PR DESCRIPTION
This PR adds the missing `exec` in for the gitlab- and sidekiq-run-scripts. This enables them to be stopped and restarted properly.
